### PR TITLE
Variable input size

### DIFF
--- a/openwakeword/model.py
+++ b/openwakeword/model.py
@@ -295,12 +295,15 @@ class Model():
                 prediction = self.model_prediction_function[mdl](
                     self.preprocessor.get_features(self.model_inputs[mdl])
                 )
-            elif n_prepared_samples < 1280:
-                if len(self.prediction_buffer[mdl]) > 0:
-                    prediction = [[[self.prediction_buffer[mdl][-1]]]]
-                else:
-                    for int_label, cls in self.class_mapping[mdl].items():
-                        prediction = [[[0]*(int(int_label)+1)]]
+            elif n_prepared_samples < 1280:  # get previous prediction if there aren't enough samples
+                if self.model_outputs[mdl] == 1:
+                    if len(self.prediction_buffer[mdl]) > 0:
+                        prediction = [[[self.prediction_buffer[mdl][-1]]]]
+                    else:
+                        prediction = [[[0]]]
+                elif self.model_outputs[mdl] != 1:
+                    n_classes = max([int(i) for i in self.class_mapping[mdl].keys()])
+                    prediction = [[[0]*(n_classes+1)]]
 
             if self.model_outputs[mdl] == 1:
                 predictions[mdl] = prediction[0][0][0]

--- a/openwakeword/model.py
+++ b/openwakeword/model.py
@@ -97,7 +97,7 @@ class Model():
                         raise ValueError("Could not find pretrained model for model name '{}'".format(i))
                     else:
                         wakeword_models[ndx] = matching_model[0]
-                        wakeword_model_names.append(matching_model[0].split(os.path.sep)[-1])
+                        wakeword_model_names.append(i)
 
         # Create attributes to store models and metadata
         self.models = {}

--- a/openwakeword/utils.py
+++ b/openwakeword/utils.py
@@ -162,7 +162,7 @@ class AudioFeatures():
         self.melspectrogram_buffer = np.ones((76, 32))  # n_frames x num_features
         self.melspectrogram_max_len = 10*97  # 97 is the number of frames in 1 second of 16hz audio
         self.accumulated_samples = 0  # the samples added to the buffer since the audio preprocessor was last called
-        # self.feature_buffer = np.vstack([self._get_embeddings(np.random.randint(-1000, 1000, 1280).astype(np.int16)) for _ in range(10)])
+        self.raw_data_remainder = np.empty(0)
         self.feature_buffer = self._get_embeddings(np.random.randint(-1000, 1000, 16000*4).astype(np.int16))
         self.feature_buffer_max_len = 120  # ~10 seconds of feature buffer history
 
@@ -377,6 +377,9 @@ class AudioFeatures():
         clip is calculated. It's unclear if this difference is significant and will impact model performance.
         In particular padding with 0 or very small values seems to demonstrate the differences well.
         """
+        if len(self.raw_data_buffer) < 400:
+            raise ValueError("The number of input frames must be at least 400 samples @ 16khz (25 ms)!")
+
         self.melspectrogram_buffer = np.vstack(
             (self.melspectrogram_buffer, self._get_melspectrogram(list(self.raw_data_buffer)[-n_samples-160*3:]))
         )
@@ -388,18 +391,25 @@ class AudioFeatures():
         """
         Adds raw audio data to the input buffer
         """
-        if len(x) < 400:
-            raise ValueError("The number of input frames must be at least 400 samples @ 16khz (25 ms)!")
         self.raw_data_buffer.extend(x.tolist() if isinstance(x, np.ndarray) else x)
 
     def _streaming_features(self, x):
-        # if len(x) != 1280:
-        #     raise ValueError("You must provide input samples in frames of 1280 samples @ 1600khz."
-        #                      f"Received a frame of {len(x)} samples.")
+        # Add raw audio data to buffer, temporarily storing extra frames if not an even number of 80 ms chunks
+        processed_samples = 0
+        if self.raw_data_remainder.shape[0] != 0:
+            x = np.concatenate((self.raw_data_remainder, x))
 
-        # Add raw audio data to buffer
-        self._buffer_raw_data(x)
-        self.accumulated_samples += len(x)
+        if x.shape[0] < 1280 and self.accumulated_samples == 0:
+            self._buffer_raw_data(x)
+            self.accumulated_samples += len(x)
+
+        elif (x.shape[0] >= 1280 and self.accumulated_samples == 0) or \
+             (self.accumulated_samples != 0 and self.accumulated_samples + x.shape[0] >= 1280):
+            remainder = (self.accumulated_samples + x.shape[0]) % 1280
+            x_even_chunks = x[0:x.shape[0] - remainder]
+            self._buffer_raw_data(x_even_chunks)
+            self.accumulated_samples += len(x_even_chunks)
+            self.raw_data_remainder = x[x.shape[0] - remainder:]
 
         # Only calculate melspectrogram once minimum samples area accumulated
         if self.accumulated_samples >= 1280:
@@ -415,10 +425,13 @@ class AudioFeatures():
                                                     self.embedding_model_predict(x)))
 
             # Reset raw data buffer counter
+            processed_samples = self.accumulated_samples
             self.accumulated_samples = 0
 
         if self.feature_buffer.shape[0] > self.feature_buffer_max_len:
             self.feature_buffer = self.feature_buffer[-self.feature_buffer_max_len:, :]
+
+        return processed_samples if processed_samples != 0 else self.accumulated_samples
 
     def get_features(self, n_feature_frames: int = 16, start_ndx: int = -1):
         if start_ndx != -1:
@@ -429,7 +442,7 @@ class AudioFeatures():
             return self.feature_buffer[int(-1*n_feature_frames):, :][None, ].astype(np.float32)
 
     def __call__(self, x):
-        self._streaming_features(x)
+        return self._streaming_features(x)
 
 
 # Bulk prediction function

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ setuptools.setup(
                     'pytest-cov>=2.10.1,<3',
                     'pytest-flake8>=1.1.1,<2',
                     'flake8>=4.0,<4.1',
-                    'pytest-mypy>=0.10.0,<1'
+                    'pytest-mypy>=0.10.0,<1',
+                    'mock>=5.1,<6',
+                    'types-mock>=5.1,<6'
                 ],
         'full': [
                     'mutagen>=1.46.0,<2',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,30 +57,37 @@ class TestModels:
 
     def test_predict_with_different_frame_sizes(self):
         # Test with binary model
-        owwModel = openwakeword.Model(wakeword_models=[
+        owwModel1 = openwakeword.Model(wakeword_models=[
+                                        os.path.join("openwakeword", "resources", "models", "alexa_v0.1.onnx")
+                                      ], inference_framework="onnx")
+
+        owwModel2 = openwakeword.Model(wakeword_models=[
                                         os.path.join("openwakeword", "resources", "models", "alexa_v0.1.onnx")
                                       ], inference_framework="onnx")
 
         # Prediction on random data with integer multiples of standard chunk size (1280 samples)
-        owwModel.predict(np.random.randint(-1000, 1000, 1280).astype(np.int16))
-        owwModel.predict(np.random.randint(-1000, 1000, 1280*2).astype(np.int16))
+        predictions1 = owwModel1.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1280)
+        predictions2 = owwModel2.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1280*2)
+        np.testing.assert_approx_equal(max([i['alexa_v0.1'] for i in predictions1]), max([i['alexa_v0.1'] for i in predictions2]), 5)
 
         # Prediction on data with a chunk size not an integer multiple of 1280
-        owwModel.predict(np.random.randint(-1000, 1000, 1024).astype(np.int16))
-        owwModel.predict(np.random.randint(-1000, 1000, 1024*2).astype(np.int16))
+        predictions1 = owwModel1.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1024)
+        predictions2 = owwModel2.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1024*2)
+        np.testing.assert_approx_equal(max([i['alexa_v0.1'] for i in predictions1]), max([i['alexa_v0.1'] for i in predictions2]), 5)
 
         # Test with multiclass model
-        owwModel = openwakeword.Model(wakeword_models=[
-                                        os.path.join("openwakeword", "resources", "models", "timer_v0.1.onnx")
-                                      ], inference_framework="onnx")
+        owwModel1 = openwakeword.Model(wakeword_models=["timer"], inference_framework="onnx")
+        owwModel2 = openwakeword.Model(wakeword_models=["timer"], inference_framework="onnx")
 
         # Prediction on random data with integer multiples of standard chunk size (1280 samples)
-        owwModel.predict(np.random.randint(-1000, 1000, 1280).astype(np.int16))
-        owwModel.predict(np.random.randint(-1000, 1000, 1280*2).astype(np.int16))
+        predictions1 = owwModel1.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1280)
+        predictions2 = owwModel2.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1280*2)
+        assert abs(max([i['1_minute_timer'] for i in predictions1]) - max([i['1_minute_timer'] for i in predictions2])) < 0.00001
 
         # Prediction on data with a chunk size not an integer multiple of 1280
-        owwModel.predict(np.random.randint(-1000, 1000, 1024).astype(np.int16))
-        owwModel.predict(np.random.randint(-1000, 1000, 1024*2).astype(np.int16))
+        predictions1 = owwModel1.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1024)
+        predictions2 = owwModel2.predict_clip(os.path.join("tests", "data", "alexa_test.wav"), chunk_size=1024*2)
+        assert abs(max([i['1_minute_timer'] for i in predictions1]) - max([i['1_minute_timer'] for i in predictions2])) < 0.00001
 
     def test_exception_handling_for_inference_framework(self):
         with mock.patch.dict(sys.modules, {'onnxruntime': None}):


### PR DESCRIPTION
This PR adds proper support for variable input sizes for the audio data when calling the `predict` method. Previous versions of openWakeWord allowed for this, but if input audio arrays were not integer multiples of 1280 samples (80 ms of 16khz audio) then audio data was silently dropped (!) leading to significantly decreased accuracy.

Several misc. bugs and issues are also addressed.