### PR TITLE
Bugfix for consecutive training steps using the same batch

### DIFF
--- a/my_model.yaml
+++ b/my_model.yaml
@@ -1,0 +1,32 @@
+augmentation_batch_size: 16
+augmentation_rounds: 1
+background_paths:
+- ./audioset_16k
+- ./koda_audio
+#- ./fma
+background_paths_duplication_rate:
+- 1
+batch_n_per_class:
+  ACAV100M_sample: 1024
+  adversarial_negative: 400
+  positive: 400
+custom_negative_phrases: []
+false_positive_validation_data_path: validation_set_features.npy
+feature_data_files:
+  ACAV100M_sample: openwakeword_features_ACAV100M_2000_hrs_16bit.npy
+layer_size: 128
+max_negative_weight: 1500
+model_name: koda_stop
+model_type: dnn
+n_samples: 100000
+n_samples_val: 2000
+output_dir: ./koda_stop_24
+piper_sample_generator_path: ./piper-sample-generator
+rir_paths:
+- ./mit_rirs
+steps: 25000
+target_false_positives_per_hour: 2
+target_phrase:
+- koda stop
+tts_batch_size: 50
+include_adversarial_examples: true

--- a/openwakeword/train.py
+++ b/openwakeword/train.py
@@ -862,7 +862,7 @@ if __name__ == '__main__':
         else:
             n_cpus = n_cpus//2
         X_train = torch.utils.data.DataLoader(IterDataset(batch_generator),
-                                              batch_size=None, num_workers=n_cpus, prefetch_factor=16)
+                                              batch_size=None)
 
         X_val_fp = np.load(config["false_positive_validation_data_path"])
         X_val_fp = np.array([X_val_fp[i:i+input_shape[0]] for i in range(0, X_val_fp.shape[0]-input_shape[0], 1)])  # reshape to match model


### PR DESCRIPTION
There was a bug where consecutive training steps would use the same batch. The number of consecutive training steps using the same batch is equal to `n_cpu`. This is to do with the number of workers prefetching data in the dataloader, and somehow each of them independently keeping track of their own `data_counter` member in `mmap_batch_generator`. I don't completely understand how the prefetching caused this, all I know is that it did.

The fix substantially changes the training dynamics by bringing a lot more stochasticity into training. In particular training error is much lower and validation accuracy and recall are much higher. It's noteworthy that validation false positives are also much higher. The training logic in this codebase is quite idiosyncratic so it's likely some of the settings and logic need to be recalibrated to work well with correct minibatch SGD.

Depending on ones settings for n_steps, dataset size and number of CPUs it's also much more likely without the fix that the model won't see all the training examples. For example, if you have 100,000 positive examples and are using 50 positive examples per batch, then it should take 2,000 steps for an epoch. But if you're on a machine with 56 CPUs then without the fix your model won't see all the data because it takes 56x more steps to see the same amount of unique data samples.

Some indicative training profiles are below on my own data. Grey is without the fix, blue is with the fix. 

<img width="684" alt="Screenshot 2024-09-16 at 3 13 01 PM" src="https://github.com/user-attachments/assets/12cbaa3c-a194-4a0a-a131-5b3e46c84aee">
<img width="684" alt="Screenshot 2024-09-16 at 3 14 48 PM" src="https://github.com/user-attachments/assets/824e24d7-5e4e-438b-9c7d-9839300de60b">

Note that I made a number of other changes to the training code as part of the runs that gave the above profile. Most notably disabling the max_negative_weight scaling, so it's merely indicative. A comparison based on the state of the code in this PR is made below, after reverting my other changes:

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
-- | Accuracy | Recall | FPPH
-- | -- | -- | --
No fix | 0.674 | 0.350 | 1.150
Fix | 0.764 | 0.534 | 17.080



