### PR TITLE
Adding LiteRT and more flexibility

### DIFF
--- a/openwakeword/model.py
+++ b/openwakeword/model.py
@@ -111,7 +111,15 @@ class Model():
         # Do imports for  inference framework
         if inference_framework == "tflite":
             try:
-                import tflite_runtime.interpreter as tflite
+                try:
+                    # Attempt to import the newer LiteRT runtime
+                    import ai_edge_litert.interpreter as tflite
+                except ImportError:
+                    try:
+                        # Fallback to the original tflite_runtime if LiteRT is unavailable
+                        import tflite_runtime.interpreter as tflite
+                    except ImportError:
+                        raise ImportError("Neither LiteRT nor TensorFlow Lite runtime found. Please install `ai_edge_litert` or `tflite_runtime`.")
 
                 def tflite_predict(tflite_interpreter, input_index, output_index, x):
                     tflite_interpreter.set_tensor(input_index, x)

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,16 @@ def build_additional_requires():
 
 setuptools.setup(
     name="openwakeword",
-    version="0.6.0",
+    version="0.6.1",
     install_requires=[
-        'onnxruntime>=1.10.0,<2',
-        'tflite-runtime>=2.8.0,<3; platform_system == "Linux"',
         'tqdm>=4.0,<5.0',
         'scipy>=1.3,<2',
         'scikit-learn>=1,<2',
         'requests>=2.0,<3',
     ],
     extras_require={
+        'onnx': ['onnxruntime>=1.10.0,<2'],
+        'tflite': ['tflite-runtime>=2.8.0,<3; platform_system == "Linux"'],
         'test': [
                     'pytest>=7.2.0,<8',
                     'pytest-cov>=2.10.1,<3',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
     ],
     extras_require={
         'onnx': ['onnxruntime>=1.10.0,<2'],
-        'tflite': ['tflite-runtime>=2.8.0,<3; platform_system == "Linux"'],
+        'tflite': ['tflite-runtime>=2.8.0,<3'],
+        'litert': ['ai-edge-litert>=1.0.1,<2'],
         'test': [
                     'pytest>=7.2.0,<8',
                     'pytest-cov>=2.10.1,<3',


### PR DESCRIPTION
Added LiteRT based on suggestion here(#205)

I moved onnx/tflite-runtime to extra dependencies because it makes it impossible to run this on Python 3.12 (there is no tflite for it but onnx is fine).