### PR TITLE
Fix tflite-runtime dependency for Python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     version="0.6.0",
     install_requires=[
         'onnxruntime>=1.10.0,<2',
-        'tflite-runtime>=2.8.0,<3; platform_system == "Linux"',
+        'tflite-runtime>=2.8.0,<3; platform_system == "Linux" and python_version < "3.12"',
         'tqdm>=4.0,<5.0',
         'scipy>=1.3,<2',
         'scikit-learn>=1,<2',


### PR DESCRIPTION
The tflite-runtime package only provides wheels for Python versions up to 3.11. This change restricts the dependency to Python < 3.12 to prevent installation failures on newer Python versions.