### PR TITLE
corrected wrong wake word reference in hey_jarvis.md

### DIFF
--- a/docs/models/hey_jarvis.md
+++ b/docs/models/hey_jarvis.md
@@ -50,7 +50,7 @@ Clips were generated both with the trained speaker embeddings, and also mixtures
 
 The following phrases were included in the training data:
 
-1) "hey mycroft"
+1) "hey jarvis"
 
 After generating the synthetic positive wakewords, they are augmented in two ways:
 


### PR DESCRIPTION
I am assuming that the "hey jarvis" model was trained on the phrase "hey jarvis" and not "hey mycroft".

It was bugging me so i decided to do this pr